### PR TITLE
Adding integration tests for CDN service

### DIFF
--- a/lib/cdn/createService.js
+++ b/lib/cdn/createService.js
@@ -1,0 +1,34 @@
+var pkgcloud = require('pkgcloud'),
+  logging = require('../common/logging'),
+  config = require('../common/config');
+
+var log = logging.getLogger(process.env.PKGCLOUD_LOG_LEVEL || 'debug');
+
+var provider = process.argv[2];
+
+var client = pkgcloud.cdn.createClient(config.getConfig(provider, 4));
+
+client.on('log::*', logging.logFunction);
+
+var options = {
+  name: process.argv[3],
+  domains: [
+    {
+      domain: process.argv[4]
+    }
+  ],
+  origins: [
+    {
+      origin: process.argv[5]
+    }
+  ],
+  flavorId: process.argv[6]
+}    
+
+client.createService(options, function (err, service) {
+  if (err) {
+    log.error(err);
+    return;
+  }
+  log.info(service.toJSON());
+});

--- a/lib/cdn/deleteService.js
+++ b/lib/cdn/deleteService.js
@@ -1,0 +1,19 @@
+var pkgcloud = require('pkgcloud'),
+  logging = require('../common/logging'),
+  config = require('../common/config');
+
+var log = logging.getLogger(process.env.PKGCLOUD_LOG_LEVEL || 'debug');
+
+var provider = process.argv[2];
+
+var client = pkgcloud.cdn.createClient(config.getConfig(provider, 1));
+
+client.on('log::*', logging.logFunction);
+
+client.deleteService(process.argv[3], function (err) {
+  if (err) {
+    log.error(err);
+    return;
+  }
+  log.info("Service " + process.argv[3] + " successfully deleted.");
+});

--- a/lib/cdn/deleteServiceCachedAssets.js
+++ b/lib/cdn/deleteServiceCachedAssets.js
@@ -1,0 +1,19 @@
+var pkgcloud = require('pkgcloud'),
+  logging = require('../common/logging'),
+  config = require('../common/config');
+
+var log = logging.getLogger(process.env.PKGCLOUD_LOG_LEVEL || 'debug');
+
+var provider = process.argv[2];
+
+var client = pkgcloud.cdn.createClient(config.getConfig(provider, 1));
+
+client.on('log::*', logging.logFunction);
+
+client.deleteServiceCachedAssets(process.argv[3], function (err) {
+  if (err) {
+    log.error(err);
+    return;
+  }
+  log.info("All cached assets of service " + process.argv[3] + " successfully deleted.");
+});

--- a/lib/cdn/getFlavor.js
+++ b/lib/cdn/getFlavor.js
@@ -1,0 +1,19 @@
+var pkgcloud = require('pkgcloud'),
+  logging = require('../common/logging'),
+  config = require('../common/config');
+
+var log = logging.getLogger(process.env.PKGCLOUD_LOG_LEVEL || 'debug');
+
+var provider = process.argv[2];
+
+var client = pkgcloud.cdn.createClient(config.getConfig(provider, 1));
+
+client.on('log::*', logging.logFunction);
+
+client.getFlavor(process.argv[3], function (err, flavor) {
+  if (err) {
+    log.error(err);
+    return;
+  }
+  log.info(flavor.toJSON());
+});

--- a/lib/cdn/getFlavors.js
+++ b/lib/cdn/getFlavors.js
@@ -1,0 +1,21 @@
+var pkgcloud = require('pkgcloud'),
+  logging = require('../common/logging'),
+  config = require('../common/config');
+
+var log = logging.getLogger(process.env.PKGCLOUD_LOG_LEVEL || 'debug');
+
+var provider = process.argv[2];
+
+var client = pkgcloud.cdn.createClient(config.getConfig(provider));
+
+client.on('log::*', logging.logFunction);
+
+client.getFlavors(function (err, flavors) {
+  if (err) {
+    log.error(err);
+    return;
+  }
+  flavors.forEach(function (flavor) {
+    log.info(flavor.toJSON());
+  });
+});

--- a/lib/cdn/getHomeDocument.js
+++ b/lib/cdn/getHomeDocument.js
@@ -1,0 +1,19 @@
+var pkgcloud = require('pkgcloud'),
+  logging = require('../common/logging'),
+  config = require('../common/config');
+
+var log = logging.getLogger(process.env.PKGCLOUD_LOG_LEVEL || 'debug');
+
+var provider = process.argv[2];
+
+var client = pkgcloud.cdn.createClient(config.getConfig(provider));
+
+client.on('log::*', logging.logFunction);
+
+client.getHomeDocument(function (err, homeDocument) {
+  if (err) {
+    log.error(err);
+    return;
+  }
+  log.info(homeDocument);
+});

--- a/lib/cdn/getPing.js
+++ b/lib/cdn/getPing.js
@@ -1,0 +1,19 @@
+var pkgcloud = require('pkgcloud'),
+  logging = require('../common/logging'),
+  config = require('../common/config');
+
+var log = logging.getLogger(process.env.PKGCLOUD_LOG_LEVEL || 'debug');
+
+var provider = process.argv[2];
+
+var client = pkgcloud.cdn.createClient(config.getConfig(provider));
+
+client.on('log::*', logging.logFunction);
+
+client.getPing(function (err) {
+  if (err) {
+    log.error(err);
+    return;
+  }
+  log.info('Ping successful. No errors.');
+});

--- a/lib/cdn/getService.js
+++ b/lib/cdn/getService.js
@@ -1,0 +1,19 @@
+var pkgcloud = require('pkgcloud'),
+  logging = require('../common/logging'),
+  config = require('../common/config');
+
+var log = logging.getLogger(process.env.PKGCLOUD_LOG_LEVEL || 'debug');
+
+var provider = process.argv[2];
+
+var client = pkgcloud.cdn.createClient(config.getConfig(provider, 1));
+
+client.on('log::*', logging.logFunction);
+
+client.getService(process.argv[3], function (err, service) {
+  if (err) {
+    log.error(err);
+    return;
+  }
+  log.info(service.toJSON());
+});

--- a/lib/cdn/getServices.js
+++ b/lib/cdn/getServices.js
@@ -1,0 +1,21 @@
+var pkgcloud = require('pkgcloud'),
+  logging = require('../common/logging'),
+  config = require('../common/config');
+
+var log = logging.getLogger(process.env.PKGCLOUD_LOG_LEVEL || 'debug');
+
+var provider = process.argv[2];
+
+var client = pkgcloud.cdn.createClient(config.getConfig(provider));
+
+client.on('log::*', logging.logFunction);
+
+client.getServices(function (err, services) {
+  if (err) {
+    log.error(err);
+    return;
+  }
+  services.forEach(function (service) {
+    log.info(service.toJSON());
+  });
+});

--- a/lib/cdn/updateService.js
+++ b/lib/cdn/updateService.js
@@ -1,0 +1,32 @@
+var pkgcloud = require('pkgcloud'),
+  logging = require('../common/logging'),
+  config = require('../common/config');
+
+var log = logging.getLogger(process.env.PKGCLOUD_LOG_LEVEL || 'debug');
+
+var provider = process.argv[2];
+
+var client = pkgcloud.cdn.createClient(config.getConfig(provider, 2));
+
+client.on('log::*', logging.logFunction);
+
+client.getService(process.argv[3], function(err, service) {
+  if (err) {
+    log.error(err);
+    return;
+  }
+
+  service.origins = [
+    {
+      origin: process.argv[4]
+    }
+  ];
+
+  client.updateService(service, function (err, service) {
+    if (err) {
+      log.error(err);
+      return;
+    }
+    log.info(service.toJSON());
+  });
+});


### PR DESCRIPTION
This PR adds integration tests for the CDN service. Note that all integration tests work with Rackspace except for the update service test. This API is currently not supported and possibly changing as well.
