### PR TITLE
added createServer.js for HP provider to allow specified network id

### DIFF
--- a/lib/providers/hp/compute/createServer.js
+++ b/lib/providers/hp/compute/createServer.js
@@ -1,0 +1,31 @@
+var pkgcloud = require('pkgcloud'),
+  logging = require('../../../common/logging'),
+  config = require('../../../common/config'),
+  _ = require('underscore');
+
+var log = logging.getLogger(process.env.PKGCLOUD_LOG_LEVEL || 'debug');
+
+var provider = process.argv[2];
+
+var client = pkgcloud.compute.createClient(config.getConfig(provider, 5));
+
+client.on('log::*', logging.logFunction);
+
+var options = {
+  name: process.argv[3],
+  flavor: process.argv[4],
+  image: process.argv[5],
+  keyname: process.argv[6],
+  networks: [{
+    uuid: process.argv[7],
+  }]
+};
+
+client.createServer(options, function(err, server) {
+  if (err) {
+    log.error(err);
+    return;
+  }
+
+  log.info(server.toJSON());
+});


### PR DESCRIPTION
For createServer call, network id is required when more than one networks available on HP Helion cloud
